### PR TITLE
Install laminas-dependency-plugin during migration

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -52,6 +52,12 @@ class MigrateCommand extends Command
                  'The repository name to migrate'
              )
              ->addOption(
+                 'no-install-dependency-plugin',
+                 'p',
+                 InputOption::VALUE_NONE,
+                 'Do not install laminas/laminas-dependency-plugin'
+             )
+             ->addOption(
                  'local',
                  'l',
                  InputOption::VALUE_NONE,
@@ -67,7 +73,8 @@ class MigrateCommand extends Command
 
         $repository = new ThirdPartyRepository(
             $input->getArgument('path'),
-            $input->getOption('name')
+            $input->getOption('name'),
+            ! (bool) $input->getOption('no-install-dependency-plugin')
         );
 
         foreach ($this->fixtures as $fixtureName) {

--- a/src/Fixture/ThirdPartyComposerFixture.php
+++ b/src/Fixture/ThirdPartyComposerFixture.php
@@ -6,29 +6,39 @@ namespace Laminas\Transfer\Fixture;
 
 use Laminas\Transfer\Helper\JsonWriter;
 use Laminas\Transfer\Repository;
+use Laminas\Transfer\ThirdPartyRepository;
 
 use function current;
 use function file_get_contents;
 use function json_decode;
+use function ksort;
 use function unlink;
 
+use const SORT_NATURAL;
+
 /**
+ * Migrate a composer.json for a userland project or third-party library.
+ *
  * Replaces all references to ZF/ZendFramework/Zend in composer.json.
+ *
  * Deletes composer.lock file.
+ *
+ * Adds laminas-dependency-plugin as a dependency, ensuring Laminas packages
+ * are used in place of ZF packages when installed as nested dependencies.
  */
 class ThirdPartyComposerFixture extends AbstractFixture
 {
     public function process(Repository $repository) : void
     {
-        $composerLock = current($repository->files('composer.lock'));
-        if ($composerLock) {
-            unlink($composerLock);
-        }
-
         $composer = current($repository->files('composer.json'));
         if (! $composer) {
             $this->writeln('<error>SKIP</error> No composer.json found.');
             return;
+        }
+
+        $composerLock = current($repository->files('composer.lock'));
+        if ($composerLock) {
+            unlink($composerLock);
         }
 
         $content = file_get_contents($composer);
@@ -37,14 +47,32 @@ class ThirdPartyComposerFixture extends AbstractFixture
 
         $json = json_decode($content, true);
 
-        // Remove the type if library, as it is default type
+        // Remove the type of library, as it is default type
         if (isset($json['type']) && $json['type'] === 'library') {
             unset($json['type']);
+        }
+
+        if ($repository instanceof ThirdPartyRepository
+            && $repository->installDependencyPlugin()
+        ) {
+            $json = $this->injectDependencyPlugin($json);
         }
 
         // Sort packages
         $json['config']['sort-packages'] = true;
 
         JsonWriter::write($composer, $json);
+    }
+
+    private function injectDependencyPlugin(array $json) : array
+    {
+        // Add dependency for laminas-dependency-plugin
+        $json['require'] = $json['require'] ?? [];
+        $json['require']['laminas/laminas-dependency-plugin'] = '^0.1.1';
+
+        // Sort packages
+        ksort($json['require'], SORT_NATURAL);
+
+        return $json;
     }
 }

--- a/src/ThirdPartyRepository.php
+++ b/src/ThirdPartyRepository.php
@@ -10,13 +10,17 @@ use function strpos;
 
 class ThirdPartyRepository extends Repository
 {
+    /** @var bool */
+    private $installDependencyPlugin;
+
     /**
      * The name is not relevant to third-party code, and is nullable. However,
      * the path is required.
      */
-    public function __construct(string $path, ?string $name = null)
+    public function __construct(string $path, ?string $name, bool $installDependencyPlugin = true)
     {
         parent::__construct($name ?: '', $path);
+        $this->installDependencyPlugin = $installDependencyPlugin;
     }
 
     /**
@@ -29,5 +33,10 @@ class ThirdPartyRepository extends Repository
         return array_values(array_filter($fileList, static function (string $file) : bool {
             return strpos($file, '/vendor/') === false;
         }));
+    }
+
+    public function installDependencyPlugin() : bool
+    {
+        return $this->installDependencyPlugin;
     }
 }


### PR DESCRIPTION
Adds functionality to the ThirdPartyComposerFixture to install the laminas-dependency-plugin in the project. This is done to ensure that any nested dependencies on ZF packages receive Laminas equivalents instead.

A flag to the migrate command allows disabling this behavior if desired; the behavior is _default_ however.

This is both an alternative **and** a complement to #13; I'd suggest we provide both, as #13's functionality can be run independently of the `migrate` command, and as a one-off (instead of having the plugin intercept forever, until removed).