### PR TITLE
Adds empty line after PHP open tag and before PHPDoc comment

### DIFF
--- a/src/Fixture/LicenseFixture.php
+++ b/src/Fixture/LicenseFixture.php
@@ -75,6 +75,8 @@ EOS;
             1
         );
 
+        $content = str_replace("<?php\n/**", "<?php\n\n/**", $content);
+
         file_put_contents($file, $content);
     }
 }


### PR DESCRIPTION
PSR-12 requires one empty line after PHP open tag, so we can do it on migration to Laminas!


Example:

```php
<?php

/**
 * @see       https://github.com/laminas/laminas-developer-tools for the canonical source repository
 * @copyright https://github.com/laminas/laminas-developer-tools/blob/master/COPYRIGHT.md
 * @license   https://github.com/laminas/laminas-developer-tools/blob/master/LICENSE.md New BSD License
 */

namespace LaminasDeveloperTools;
```