### PR TITLE
Extract method move in Repository class

### DIFF
--- a/src/Fixture/Custom/ZendDeveloperTools.php
+++ b/src/Fixture/Custom/ZendDeveloperTools.php
@@ -14,9 +14,7 @@ use function dirname;
 use function file_get_contents;
 use function file_put_contents;
 use function preg_replace;
-use function rename;
 use function strtr;
-use function system;
 
 /**
  * Renames view/zend-developer-tools to view/laminas-developer-tools
@@ -31,12 +29,7 @@ class ZendDeveloperTools extends AbstractFixture
     {
         $legacyPath = $repository->getPath() . '/view/zend-developer-tools';
         $newPath = $repository->getPath() . '/view/' . $repository->replace('zend-developer-tools');
-
-        if ($repository->isUnderGit()) {
-            system('git mv ' . $legacyPath . ' ' . $newPath);
-        } else {
-            rename($legacyPath, $newPath);
-        }
+        $repository->move($legacyPath, $newPath);
 
         $files = array_merge(
             $repository->files('*zenddevelopertools*'),
@@ -45,12 +38,7 @@ class ZendDeveloperTools extends AbstractFixture
         foreach ($files as $file) {
             $basename = basename($file);
             $newFile = dirname($file) . '/' . $repository->replace($basename);
-
-            if ($repository->isUnderGit()) {
-                system('git mv ' . $file . ' ' . $newFile);
-            } else {
-                rename($file, $newFile);
-            }
+            $repository->move($file, $newFile);
         }
 
         $phpunitConfig = current($repository->files('phpunit.xml.dist'));

--- a/src/Fixture/Custom/ZendText.php
+++ b/src/Fixture/Custom/ZendText.php
@@ -10,10 +10,8 @@ use Laminas\Transfer\Repository;
 use function file_get_contents;
 use function file_put_contents;
 use function preg_replace;
-use function rename;
 use function str_repeat;
 use function str_replace;
-use function system;
 
 use const PHP_EOL;
 
@@ -46,11 +44,7 @@ class ZendText extends AbstractFixture
             file_put_contents($file, $content);
 
             $newName = str_replace('zend-framework', 'laminas-project', $file);
-            if ($repository->isUnderGit()) {
-                system('git mv ' . $file . ' ' . $newName);
-            } else {
-                rename($file, $newName);
-            }
+            $repository->move($file, $newName);
         }
 
         $repository->addReplacedContentFiles($files);

--- a/src/Fixture/SourceFixture.php
+++ b/src/Fixture/SourceFixture.php
@@ -17,7 +17,6 @@ use function implode;
 use function is_dir;
 use function mkdir;
 use function preg_match_all;
-use function rename;
 use function str_ireplace;
 use function strpos;
 use function strtr;
@@ -65,11 +64,7 @@ class SourceFixture extends AbstractFixture
                 if (! is_dir($dirname)) {
                     mkdir($dirname, 0777, true);
                 }
-                if ($repository->isUnderGit()) {
-                    system('git mv ' . $php . ' ' . $newName);
-                } else {
-                    rename($php, $newName);
-                }
+                $repository->move($php, $newName);
                 $phps[$k] = $newName;
             }
         }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -17,8 +17,10 @@ use function getcwd;
 use function in_array;
 use function is_dir;
 use function preg_quote;
+use function rename;
 use function str_replace;
 use function strtr;
+use function system;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -276,8 +278,17 @@ class Repository
         ]);
     }
 
-    public function isUnderGit() : bool
+    private function isUnderGit() : bool
     {
         return $this->underGit;
+    }
+
+    public function move(string $source, string $target) : void
+    {
+        if ($this->isUnderGit()) {
+            system('git mv ' . $source . ' ' . $target);
+        } else {
+            rename($source, $target);
+        }
     }
 }


### PR DESCRIPTION
We are renaming files/directories in couple fixtures already, so it's better to have extracted this method in the common place.

Also changed visibility for method `isUnderGit` as it is no longer needed to be public.