### PR TITLE
Updated archived repositories list

### DIFF
--- a/src/Command/DependenciesCommand.php
+++ b/src/Command/DependenciesCommand.php
@@ -71,6 +71,7 @@ class DependenciesCommand extends Command
         'ZendService_WindowsAzure',
         'ZendSkeletonModule',
         'ZendTimeSync',
+        'zend-debug',
         'zend-version',
         'zf1-extras',
         'zf1',
@@ -89,7 +90,6 @@ class DependenciesCommand extends Command
         'zf3-web',
         'zfbot',
         'maintainers',
-        'statuslib-example',
     ];
 
     /** @var array[] */

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -55,6 +55,10 @@ class Repository
         'zendframework/zendpdf' => 'zendframework/zendpdf',
         'Zend\\Version' => 'Zend\\Version',
         'zendframework/zend-version' => 'zendframework/zend-version',
+        'zend-version' => 'zend-version',
+        'Zend\\Debug' => 'Zend\\Debug',
+        'zendframework/zend-debug' => 'zendframework/zend-debug',
+        'zend-debug' => 'zend-debug',
         // Rewrite rules:
         'ZendXml;' => 'Laminas\\Xml;',
         'ZendXml\\\\' => 'Laminas\\\\Xml\\\\',


### PR DESCRIPTION
- we are not moving zend-debug (archived)
  This package is used in ZendDeveloperTools.

- we are movin zfcampus/statuslib-example as we have references to this
  library in tutorials