### PR TITLE
Hotfix: license fixture - better recognise license doc header

### DIFF
--- a/src/Fixture/LicenseFixture.php
+++ b/src/Fixture/LicenseFixture.php
@@ -13,7 +13,6 @@ use function file_put_contents;
 use function preg_replace;
 use function sprintf;
 use function str_replace;
-use function system;
 
 /**
  * Renames LICENSE.txt to LICENSE.md
@@ -36,7 +35,7 @@ EOS;
     {
         $licenseTxt = current($repository->files('LICENSE.txt'));
         if ($licenseTxt) {
-            system('git mv ' . $licenseTxt . ' ' . str_replace('.txt', '.md', $licenseTxt));
+            $repository->move($licenseTxt, str_replace('.txt', '.md', $licenseTxt));
         }
 
         $license = current($repository->files('LICENSE.md'));
@@ -56,7 +55,7 @@ EOS;
             $repository->getPath() . '/COPYRIGHT.md',
             $repository->getTemplateText($repository::T_COPYRIGHT)
         );
-        system('git add ' . $repository->getPath() . '/COPYRIGHT.md');
+        $repository->add($repository->getPath() . '/COPYRIGHT.md');
 
         $docheader = current($repository->files('.docheader'));
         if ($docheader) {
@@ -69,7 +68,7 @@ EOS;
         $content = file_get_contents($file);
 
         $content = preg_replace(
-            '/\/\*\*.+?@license.+? \*\//s',
+            '/\/\*\*.+?@license.+?^\s*\*\//sm',
             sprintf(self::HEADER, $repository->getNewName()),
             $content,
             1

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -331,6 +331,15 @@ class Repository
         return $this->underGit;
     }
 
+    public function add(string $filename) : void
+    {
+        if (! $this->isUnderGit()) {
+            return;
+        }
+
+        system('git add ' . $filename);
+    }
+
     public function move(string $source, string $target) : void
     {
         if ($this->isUnderGit()) {

--- a/test/Fixture/LicenseFixtureTest.php
+++ b/test/Fixture/LicenseFixtureTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Transfer\Fixture;
+
+class LicenseFixtureTest extends AbstractFixtureTest
+{
+}

--- a/test/Fixture/TestAsset/License/ZendExpressiveRouter/src/RouteResult.php
+++ b/test/Fixture/TestAsset/License/ZendExpressiveRouter/src/RouteResult.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Value object representing the results of routing.
+ *
+ * RouterInterface::match() is defined as returning a RouteResult instance,
+ * which will contain the following state:
+ *
+ * - isSuccess()/isFailure() indicate whether routing succeeded or not.
+ * - On success, it will contain:
+ *   - the matched route name (typically the path)
+ *   - the matched route middleware
+ *   - any parameters matched by routing
+ * - On failure:
+ *   - isMethodFailure() further qualifies a routing failure to indicate that it
+ *     was due to using an HTTP method not allowed for the given path.
+ *   - If the failure was due to HTTP method negotiation, it will contain the
+ *     list of allowed HTTP methods.
+ *
+ * RouteResult instances are consumed by the Application in the routing
+ * middleware.
+ */
+class RouteResult implements MiddlewareInterface
+{
+    /**
+     * @var null|string[]
+     */
+    private $allowedMethods = [];
+
+    /**
+     * @var array
+     */
+    private $matchedParams = [];
+
+    /**
+     * @var string
+     */
+    private $matchedRouteName;
+
+    /**
+     * Route matched during routing
+     *
+     * @since 1.3.0
+     * @var Route $route
+     */
+    private $route;
+
+    /**
+     * @var bool Success state of routing.
+     */
+    private $success;
+
+    /**
+     * Create an instance representing a route succes from the matching route.
+     *
+     * @param array $params Parameters associated with the matched route, if any.
+     */
+    public static function fromRoute(Route $route, array $params = []) : self
+    {
+        $result                = new self();
+        $result->success       = true;
+        $result->route         = $route;
+        $result->matchedParams = $params;
+        return $result;
+    }
+
+    /**
+     * Create an instance representing a route failure.
+     *
+     * @param null|array $methods HTTP methods allowed for the current URI, if any.
+     *     null is equivalent to allowing any HTTP method; empty array means none.
+     */
+    public static function fromRouteFailure(?array $methods) : self
+    {
+        $result = new self();
+        $result->success = false;
+        $result->allowedMethods = $methods;
+
+        return $result;
+    }
+
+    /**
+     * Process the result as middleware.
+     *
+     * If the result represents a failure, it passes handling to the handler.
+     *
+     * Otherwise, it processes the composed middleware using the provide request
+     * and handler.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        if ($this->isFailure()) {
+            return $handler->handle($request);
+        }
+
+        return $this->getMatchedRoute()->process($request, $handler);
+    }
+
+    /**
+     * Does the result represent successful routing?
+     */
+    public function isSuccess() : bool
+    {
+        return $this->success;
+    }
+
+    /**
+     * Retrieve the route that resulted in the route match.
+     *
+     * @return false|null|Route false if representing a routing failure;
+     *     null if not created via fromRoute(); Route instance otherwise.
+     */
+    public function getMatchedRoute()
+    {
+        return $this->isFailure() ? false : $this->route;
+    }
+
+    /**
+     * Retrieve the matched route name, if possible.
+     *
+     * If this result represents a failure, return false; otherwise, return the
+     * matched route name.
+     *
+     * @return false|string
+     */
+    public function getMatchedRouteName()
+    {
+        if ($this->isFailure()) {
+            return false;
+        }
+
+        if (! $this->matchedRouteName && $this->route) {
+            $this->matchedRouteName = $this->route->getName();
+        }
+
+        return $this->matchedRouteName;
+    }
+
+    /**
+     * Returns the matched params.
+     *
+     * Guaranted to return an array, even if it is simply empty.
+     */
+    public function getMatchedParams() : array
+    {
+        return $this->matchedParams;
+    }
+
+    /**
+     * Is this a routing failure result?
+     */
+    public function isFailure() : bool
+    {
+        return (! $this->success);
+    }
+
+    /**
+     * Does the result represent failure to route due to HTTP method?
+     */
+    public function isMethodFailure() : bool
+    {
+        if ($this->isSuccess() || $this->allowedMethods === Route::HTTP_METHOD_ANY) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Retrieve the allowed methods for the route failure.
+     *
+     * @return null|string[] HTTP methods allowed
+     */
+    public function getAllowedMethods() : ?array
+    {
+        if ($this->isSuccess()) {
+            return $this->route
+                ? $this->route->getAllowedMethods()
+                : [];
+        }
+
+        return $this->allowedMethods;
+    }
+
+    /**
+     * Only allow instantiation via factory methods.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/test/Fixture/TestAsset/License/ZendExpressiveRouter/src/RouteResult.php.result
+++ b/test/Fixture/TestAsset/License/ZendExpressiveRouter/src/RouteResult.php.result
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-router for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-router/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Value object representing the results of routing.
+ *
+ * RouterInterface::match() is defined as returning a RouteResult instance,
+ * which will contain the following state:
+ *
+ * - isSuccess()/isFailure() indicate whether routing succeeded or not.
+ * - On success, it will contain:
+ *   - the matched route name (typically the path)
+ *   - the matched route middleware
+ *   - any parameters matched by routing
+ * - On failure:
+ *   - isMethodFailure() further qualifies a routing failure to indicate that it
+ *     was due to using an HTTP method not allowed for the given path.
+ *   - If the failure was due to HTTP method negotiation, it will contain the
+ *     list of allowed HTTP methods.
+ *
+ * RouteResult instances are consumed by the Application in the routing
+ * middleware.
+ */
+class RouteResult implements MiddlewareInterface
+{
+    /**
+     * @var null|string[]
+     */
+    private $allowedMethods = [];
+
+    /**
+     * @var array
+     */
+    private $matchedParams = [];
+
+    /**
+     * @var string
+     */
+    private $matchedRouteName;
+
+    /**
+     * Route matched during routing
+     *
+     * @since 1.3.0
+     * @var Route $route
+     */
+    private $route;
+
+    /**
+     * @var bool Success state of routing.
+     */
+    private $success;
+
+    /**
+     * Create an instance representing a route succes from the matching route.
+     *
+     * @param array $params Parameters associated with the matched route, if any.
+     */
+    public static function fromRoute(Route $route, array $params = []) : self
+    {
+        $result                = new self();
+        $result->success       = true;
+        $result->route         = $route;
+        $result->matchedParams = $params;
+        return $result;
+    }
+
+    /**
+     * Create an instance representing a route failure.
+     *
+     * @param null|array $methods HTTP methods allowed for the current URI, if any.
+     *     null is equivalent to allowing any HTTP method; empty array means none.
+     */
+    public static function fromRouteFailure(?array $methods) : self
+    {
+        $result = new self();
+        $result->success = false;
+        $result->allowedMethods = $methods;
+
+        return $result;
+    }
+
+    /**
+     * Process the result as middleware.
+     *
+     * If the result represents a failure, it passes handling to the handler.
+     *
+     * Otherwise, it processes the composed middleware using the provide request
+     * and handler.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        if ($this->isFailure()) {
+            return $handler->handle($request);
+        }
+
+        return $this->getMatchedRoute()->process($request, $handler);
+    }
+
+    /**
+     * Does the result represent successful routing?
+     */
+    public function isSuccess() : bool
+    {
+        return $this->success;
+    }
+
+    /**
+     * Retrieve the route that resulted in the route match.
+     *
+     * @return false|null|Route false if representing a routing failure;
+     *     null if not created via fromRoute(); Route instance otherwise.
+     */
+    public function getMatchedRoute()
+    {
+        return $this->isFailure() ? false : $this->route;
+    }
+
+    /**
+     * Retrieve the matched route name, if possible.
+     *
+     * If this result represents a failure, return false; otherwise, return the
+     * matched route name.
+     *
+     * @return false|string
+     */
+    public function getMatchedRouteName()
+    {
+        if ($this->isFailure()) {
+            return false;
+        }
+
+        if (! $this->matchedRouteName && $this->route) {
+            $this->matchedRouteName = $this->route->getName();
+        }
+
+        return $this->matchedRouteName;
+    }
+
+    /**
+     * Returns the matched params.
+     *
+     * Guaranted to return an array, even if it is simply empty.
+     */
+    public function getMatchedParams() : array
+    {
+        return $this->matchedParams;
+    }
+
+    /**
+     * Is this a routing failure result?
+     */
+    public function isFailure() : bool
+    {
+        return (! $this->success);
+    }
+
+    /**
+     * Does the result represent failure to route due to HTTP method?
+     */
+    public function isMethodFailure() : bool
+    {
+        if ($this->isSuccess() || $this->allowedMethods === Route::HTTP_METHOD_ANY) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Retrieve the allowed methods for the route failure.
+     *
+     * @return null|string[] HTTP methods allowed
+     */
+    public function getAllowedMethods() : ?array
+    {
+        if ($this->isSuccess()) {
+            return $this->route
+                ? $this->route->getAllowedMethods()
+                : [];
+        }
+
+        return $this->allowedMethods;
+    }
+
+    /**
+     * Only allow instantiation via factory methods.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/test/Fixture/TestAsset/License/ZendSoap/test/WsdlTestHelper.php
+++ b/test/Fixture/TestAsset/License/ZendSoap/test/WsdlTestHelper.php
@@ -1,0 +1,116 @@
+<?php
+/**
+* Zend Framework (http://framework.zend.com/)
+*
+* @link      http://github.com/zendframework/zf2 for the canonical source repository
+* @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+* @license   http://framework.zend.com/license/new-bsd New BSD License
+*/
+
+namespace ZendTest\Soap;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Soap\Wsdl;
+use Zend\Soap\Wsdl\ComplexTypeStrategy;
+use Zend\Soap\Wsdl\ComplexTypeStrategy\ComplexTypeStrategyInterface;
+
+/**
+* Zend_Soap_Server
+*
+* @group      Zend_Soap
+* @group      Zend_Soap_Wsdl
+**/
+class WsdlTestHelper extends TestCase
+{
+    /**
+     * @var Wsdl
+     */
+    protected $wsdl;
+    /**
+     * @var \DOMDocument
+     */
+    protected $dom;
+    /**
+     * @var \DOMXPath
+     */
+    protected $xpath;
+
+    /**
+     * @var ComplexTypeStrategy\ComplexTypeStrategyInterface
+     */
+    protected $strategy;
+
+    /**
+     * @var string
+     */
+    protected $defaultServiceName = 'MyService';
+
+    /**
+     * @var string
+     */
+    protected $defaultServiceUri = 'http://localhost/MyService.php';
+
+    public function setUp()
+    {
+        if (empty($this->strategy) or ! ($this->strategy instanceof ComplexTypeStrategyInterface)) {
+            $this->strategy = new Wsdl\ComplexTypeStrategy\DefaultComplexType();
+        }
+
+        $this->wsdl = new Wsdl($this->defaultServiceName, $this->defaultServiceUri, $this->strategy);
+
+        if ($this->strategy instanceof ComplexTypeStrategyInterface) {
+            $this->strategy->setContext($this->wsdl);
+        }
+
+        $this->dom = $this->wsdl->toDomDocument();
+        $this->dom = $this->registerNamespaces($this->dom);
+    }
+
+    /**
+     * @param \DOMDocument $obj
+     * @param string $documentNamespace
+     * @return \DOMDocument
+     */
+    public function registerNamespaces($obj, $documentNamespace = null)
+    {
+        if (empty($documentNamespace)) {
+            $documentNamespace = $this->defaultServiceUri;
+        }
+
+        $this->xpath = new \DOMXPath($obj);
+        $this->xpath->registerNamespace('unittest', Wsdl::WSDL_NS_URI);
+
+        $this->xpath->registerNamespace('tns', $documentNamespace);
+        $this->xpath->registerNamespace('soap', Wsdl::SOAP_11_NS_URI);
+        $this->xpath->registerNamespace('soap12', Wsdl::SOAP_12_NS_URI);
+        $this->xpath->registerNamespace('xsd', Wsdl::XSD_NS_URI);
+        $this->xpath->registerNamespace('soap-enc', Wsdl::SOAP_ENC_URI);
+        $this->xpath->registerNamespace('wsdl', Wsdl::WSDL_NS_URI);
+
+        return $obj;
+    }
+
+    /**
+     * @param \DOMElement $element
+     */
+    public function documentNodesTest($element = null)
+    {
+        if (! ($this->wsdl instanceof Wsdl)) {
+            return;
+        }
+
+        if (null === $element) {
+            $element = $this->wsdl->toDomDocument()->documentElement;
+        }
+
+        foreach ($element->childNodes as $node) {
+            if (in_array($node->nodeType, [XML_ELEMENT_NODE])) {
+                $this->assertNotEmpty(
+                    $node->namespaceURI,
+                    'Document element: ' . $node->nodeName . ' has no valid namespace. Line: ' . $node->getLineNo()
+                );
+                $this->documentNodesTest($node);
+            }
+        }
+    }
+}

--- a/test/Fixture/TestAsset/License/ZendSoap/test/WsdlTestHelper.php.result
+++ b/test/Fixture/TestAsset/License/ZendSoap/test/WsdlTestHelper.php.result
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-soap for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-soap/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-soap/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Soap;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Soap\Wsdl;
+use Zend\Soap\Wsdl\ComplexTypeStrategy;
+use Zend\Soap\Wsdl\ComplexTypeStrategy\ComplexTypeStrategyInterface;
+
+/**
+* Zend_Soap_Server
+*
+* @group      Zend_Soap
+* @group      Zend_Soap_Wsdl
+**/
+class WsdlTestHelper extends TestCase
+{
+    /**
+     * @var Wsdl
+     */
+    protected $wsdl;
+    /**
+     * @var \DOMDocument
+     */
+    protected $dom;
+    /**
+     * @var \DOMXPath
+     */
+    protected $xpath;
+
+    /**
+     * @var ComplexTypeStrategy\ComplexTypeStrategyInterface
+     */
+    protected $strategy;
+
+    /**
+     * @var string
+     */
+    protected $defaultServiceName = 'MyService';
+
+    /**
+     * @var string
+     */
+    protected $defaultServiceUri = 'http://localhost/MyService.php';
+
+    public function setUp()
+    {
+        if (empty($this->strategy) or ! ($this->strategy instanceof ComplexTypeStrategyInterface)) {
+            $this->strategy = new Wsdl\ComplexTypeStrategy\DefaultComplexType();
+        }
+
+        $this->wsdl = new Wsdl($this->defaultServiceName, $this->defaultServiceUri, $this->strategy);
+
+        if ($this->strategy instanceof ComplexTypeStrategyInterface) {
+            $this->strategy->setContext($this->wsdl);
+        }
+
+        $this->dom = $this->wsdl->toDomDocument();
+        $this->dom = $this->registerNamespaces($this->dom);
+    }
+
+    /**
+     * @param \DOMDocument $obj
+     * @param string $documentNamespace
+     * @return \DOMDocument
+     */
+    public function registerNamespaces($obj, $documentNamespace = null)
+    {
+        if (empty($documentNamespace)) {
+            $documentNamespace = $this->defaultServiceUri;
+        }
+
+        $this->xpath = new \DOMXPath($obj);
+        $this->xpath->registerNamespace('unittest', Wsdl::WSDL_NS_URI);
+
+        $this->xpath->registerNamespace('tns', $documentNamespace);
+        $this->xpath->registerNamespace('soap', Wsdl::SOAP_11_NS_URI);
+        $this->xpath->registerNamespace('soap12', Wsdl::SOAP_12_NS_URI);
+        $this->xpath->registerNamespace('xsd', Wsdl::XSD_NS_URI);
+        $this->xpath->registerNamespace('soap-enc', Wsdl::SOAP_ENC_URI);
+        $this->xpath->registerNamespace('wsdl', Wsdl::WSDL_NS_URI);
+
+        return $obj;
+    }
+
+    /**
+     * @param \DOMElement $element
+     */
+    public function documentNodesTest($element = null)
+    {
+        if (! ($this->wsdl instanceof Wsdl)) {
+            return;
+        }
+
+        if (null === $element) {
+            $element = $this->wsdl->toDomDocument()->documentElement;
+        }
+
+        foreach ($element->childNodes as $node) {
+            if (in_array($node->nodeType, [XML_ELEMENT_NODE])) {
+                $this->assertNotEmpty(
+                    $node->namespaceURI,
+                    'Document element: ' . $node->nodeName . ' has no valid namespace. Line: ' . $node->getLineNo()
+                );
+                $this->documentNodesTest($node);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes invalid rewrite for License headers.
It causes parsing errors at least in zend-form and zend-soap. Maybe also in other libraries.

Tests added.