### PR TITLE
Hotfix: License fixture - when closing phpdoc tag has more than one *

### DIFF
--- a/src/Fixture/LicenseFixture.php
+++ b/src/Fixture/LicenseFixture.php
@@ -68,7 +68,7 @@ EOS;
         $content = file_get_contents($file);
 
         $content = preg_replace(
-            '/\/\*\*.+?@license.+?^\s*\*\//sm',
+            '/\/\*\*.+?@license.+?^\s*\*+\//sm',
             sprintf(self::HEADER, $repository->getNewName()),
             $content,
             1

--- a/test/Fixture/TestAsset/License/ZendExpressiveRouter/src/RouteResult.php
+++ b/test/Fixture/TestAsset/License/ZendExpressiveRouter/src/RouteResult.php
@@ -3,7 +3,7 @@
  * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
  * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
- */
+ **/
 
 declare(strict_types=1);
 


### PR DESCRIPTION
It is possible that closing PHPDocs has more than one * before /.
We should handle that case as well on replacing doc header in files.