### PR TITLE
fix: bump laminas-zendframework-bridge minimum version to 0.4.2.

### DIFF
--- a/src/Fixture/ComposerFixture.php
+++ b/src/Fixture/ComposerFixture.php
@@ -136,7 +136,7 @@ class ComposerFixture extends AbstractFixture
             }
         }
 
-        $json['require']['laminas/laminas-zendframework-bridge'] = '^0.4.1 || ^1.0';
+        $json['require']['laminas/laminas-zendframework-bridge'] = '^0.4.2 || ^1.0';
 
         if ($repository->getNewName() === 'mezzio/mezzio-skeleton'
             || $repository->getNewName() === 'laminas-api-tools/api-tools-skeleton'

--- a/test/Fixture/TestAsset/Composer/ZendEventmanager/composer.json.result
+++ b/test/Fixture/TestAsset/Composer/ZendEventmanager/composer.json.result
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "laminas/laminas-zendframework-bridge": "^0.4.1 || ^1.0"
+        "laminas/laminas-zendframework-bridge": "^0.4.2 || ^1.0"
     },
     "require-dev": {
         "athletic/athletic": "^0.1",

--- a/test/Fixture/TestAsset/Composer/ZendExpressiveRouter/composer.json.result
+++ b/test/Fixture/TestAsset/Composer/ZendExpressiveRouter/composer.json.result
@@ -34,7 +34,7 @@
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
-        "laminas/laminas-zendframework-bridge": "^0.4.1 || ^1.0",
+        "laminas/laminas-zendframework-bridge": "^0.4.2 || ^1.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0"

--- a/test/Fixture/TestAsset/Composer/ZendExpressiveSkeleton/composer.json.result
+++ b/test/Fixture/TestAsset/Composer/ZendExpressiveSkeleton/composer.json.result
@@ -45,7 +45,7 @@
         "laminas/laminas-config-aggregator": "^1.0",
         "laminas/laminas-diactoros": "^1.7.1 || ^2.0",
         "laminas/laminas-stdlib": "^3.2.1",
-        "laminas/laminas-zendframework-bridge": "^0.4.1 || ^1.0",
+        "laminas/laminas-zendframework-bridge": "^0.4.2 || ^1.0",
         "mezzio/mezzio": "^3.0.1",
         "mezzio/mezzio-helpers": "^5.0"
     },

--- a/test/Fixture/TestAsset/Composer/ZendStdlib/composer.json.result
+++ b/test/Fixture/TestAsset/Composer/ZendStdlib/composer.json.result
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "laminas/laminas-zendframework-bridge": "^0.4.1 || ^1.0"
+        "laminas/laminas-zendframework-bridge": "^0.4.2 || ^1.0"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "1.7.*",

--- a/test/Fixture/TestAsset/Composer/ZendXml/composer.json.result
+++ b/test/Fixture/TestAsset/Composer/ZendXml/composer.json.result
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "laminas/laminas-zendframework-bridge": "^0.4.1 || ^1.0"
+        "laminas/laminas-zendframework-bridge": "^0.4.2 || ^1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/test/Fixture/TestAsset/Composer/ZendXmlOld/composer.json.result
+++ b/test/Fixture/TestAsset/Composer/ZendXmlOld/composer.json.result
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": "^5.3.3 || ^7.0",
-        "laminas/laminas-zendframework-bridge": "^0.4.1 || ^1.0"
+        "laminas/laminas-zendframework-bridge": "^0.4.2 || ^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7 || ^4.0",

--- a/test/Fixture/TestAsset/Composer/ZfApigilitySkeleton/composer.json.result
+++ b/test/Fixture/TestAsset/Composer/ZfApigilitySkeleton/composer.json.result
@@ -34,7 +34,7 @@
         "laminas-api-tools/api-tools-documentation": "^1.3",
         "laminas/laminas-component-installer": "^1.1.1 || ^2.1.1",
         "laminas/laminas-development-mode": "^3.2",
-        "laminas/laminas-zendframework-bridge": "^0.4.1 || ^1.0"
+        "laminas/laminas-zendframework-bridge": "^0.4.2 || ^1.0"
     },
     "require-dev": {
         "laminas-api-tools/api-tools-admin": "^1.6",

--- a/test/Fixture/TestAsset/Composer/ZfHal/composer.json.result
+++ b/test/Fixture/TestAsset/Composer/ZfHal/composer.json.result
@@ -43,7 +43,7 @@
         "laminas/laminas-stdlib": "^2.7.7 || ^3.0.1",
         "laminas/laminas-uri": "^2.5.2",
         "laminas/laminas-view": "^2.8.1",
-        "laminas/laminas-zendframework-bridge": "^0.4.1 || ^1.0",
+        "laminas/laminas-zendframework-bridge": "^0.4.2 || ^1.0",
         "psr/link": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bumps minimum supported version of laminas-zendframework-bridge to 0.4.2