### PR TITLE
Hotfix: zend-xml repository name

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -77,6 +77,7 @@ class Repository
         'ZendXmlTest\\\\' => 'LaminasTest\\\\Xml\\\\',
         'ZendXmlTest' => 'LaminasTest\\Xml',
         'ZendXml' => 'laminas-xml',
+        'zendframework/ZendXml' => 'laminas/laminas-xml',
         '/ZendXml' => '/LaminasXml',
         '/ZendXmlTest' => '/LaminasTest/Xml',
         'zendxml' => 'laminas-xml',


### PR DESCRIPTION
Because of additional rules for replacing directories in ZendXml with PSR-0
we have now wrong repository name.
Added rule to fix it: laminas/laminas-xml instead of LaminasXml.