### PR TITLE
Hotfix: file rename rule: apigility => api-tools

### DIFF
--- a/src/Fixture/SourceFixture.php
+++ b/src/Fixture/SourceFixture.php
@@ -60,6 +60,7 @@ class SourceFixture extends AbstractFixture
                 'zf-composer-' => 'laminas-composer-',
                 'zf-development-' => 'laminas-development-',
                 'zf-' => 'api-tools-',
+                'apigility' => 'api-tools',
                 'zfdeploy.php' => 'laminas-deploy',
                 'zendview' => 'laminasview',
                 'zend-' => 'laminas-',


### PR DESCRIPTION
We have `bin/apigility-upgrade-to-1.5` in `zf-apigility-admin`

It will be renamed now to `api-tools-upgrade-to-1.5` as all references in the documentation.