### PR TITLE
Hotfix: apigility-doctrine - rename assets

### DIFF
--- a/src/Fixture/Custom/ZfApigility.php
+++ b/src/Fixture/Custom/ZfApigility.php
@@ -40,7 +40,7 @@ class ZfApigility extends AbstractFixture
     {
         foreach ($files as $file) {
             $ext = strtolower(substr($file, strrpos($file, '.') + 1));
-            if (in_array($ext, ['js', 'css', 'less', 'html', 'md'], true)) {
+            if (in_array($ext, ['js', 'css', 'less', 'html', 'md', 'xml', 'yml', 'dist', 'phtml'], true)) {
                 $content = file_get_contents($file);
                 $content = $repository->replace($content);
                 file_put_contents($file, $content);
@@ -51,6 +51,8 @@ class ZfApigility extends AbstractFixture
                 'zf-apigility' => 'api-tools',
                 'apigility' => 'api-tools',
                 'zf-' => 'api-tools-',
+                'ZF' => 'Laminas',
+                'Apigility' => 'ApiTools',
             ]);
 
             if ($file !== $newName) {

--- a/src/Fixture/Custom/ZfApigilityDoctrine.php
+++ b/src/Fixture/Custom/ZfApigilityDoctrine.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Transfer\Fixture\Custom;
+
+use Laminas\Transfer\Repository;
+
+/**
+ * Process tests assets
+ */
+class ZfApigilityDoctrine extends ZfApigility
+{
+    public function process(Repository $repository) : void
+    {
+        $this->processFiles(
+            $repository,
+            $repository->files('*/ZFTestApigility*')
+        );
+    }
+}


### PR DESCRIPTION
ZFTestApigility -> LaminasTestApigility, also process all assets files:
xml, yml, phtml, dist, ...