### PR TITLE
Hotfix: database name in configuration yml files to match one from php

### DIFF
--- a/src/Fixture/Custom/ZfDoctrineQuerybuilder.php
+++ b/src/Fixture/Custom/ZfDoctrineQuerybuilder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Transfer\Fixture\Custom;
+
+use Laminas\Transfer\Repository;
+
+use function array_merge;
+
+/**
+ * Process *.yml/*.xml files (configuration in tests)
+ */
+class ZfDoctrineQuerybuilder extends ZfApigility
+{
+    public function process(Repository $repository) : void
+    {
+        $this->processFiles(
+            $repository,
+            array_merge(
+                $repository->files('*.yml'),
+                $repository->files('*.xml')
+            )
+        );
+    }
+}


### PR DESCRIPTION
Different database has been used in yml than in local.php files
(zf-doctrine-querybuilder - only tests affected)