### PR TITLE
Ensure aliasing of ZendOAuth is rewritten correctly

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -101,6 +101,7 @@ class Repository
         'zendframework/zend-debug' => 'zendframework/zend-debug',
         'zend-debug' => 'zend-debug',
         // Rewrite rules:
+        'use ZendOAuth as ' => 'use Laminas\OAuth as',
         'ZendXml;' => 'Laminas\\Xml;',
         'ZendXml\\\\' => 'Laminas\\\\Xml\\\\',
         'ZendXmlTest\\\\' => 'LaminasTest\\\\Xml\\\\',


### PR DESCRIPTION
Maps "use ZendOAuth as " to "use Laminas\OAuth as ".